### PR TITLE
Path template can now include of owner derived attribute values.

### DIFF
--- a/AttachmentBehavior/AttachmentBehavior.php
+++ b/AttachmentBehavior/AttachmentBehavior.php
@@ -38,7 +38,7 @@
  * @property string $path
  * @private string $filename
  * @private integer $filesize 
- * @private string $ParsedPath
+ * @private string $parsedPath
  * */
 class AttachmentBehavior extends CActiveRecordBehavior {    
     
@@ -90,14 +90,14 @@ class AttachmentBehavior extends CActiveRecordBehavior {
     {
         if($style == ''){
             if($this->hasAttachment())
-                return $this->Owner->{$this->attribute};
+                return $this->Owner->filename;
             elseif($this->fallback_image != '')
                 return $this->fallback_image;
             else
                 return '';
         }else{
             if(isset($this->styles[$style])){
-                $im = preg_replace('/\.(.*)$/','-'.$style.'\\0',$this->Owner->{$this->attribute});                
+                $im = preg_replace('/\.(.*)$/','-'.$style.'\\0',$this->Owner->filename);                
                 if(file_exists($im))
                     return  $im;
                 elseif(isset($this->fallback_image))
@@ -112,7 +112,7 @@ class AttachmentBehavior extends CActiveRecordBehavior {
      */
     public function hasAttachment()
     {
-        return file_exists($this->Owner->{$this->attribute});
+        return file_exists($this->Owner->filename);
     }
     
     /**
@@ -151,7 +151,7 @@ class AttachmentBehavior extends CActiveRecordBehavior {
             preg_match('/\.(.*)$/',$file->name,$matches);
             $this->file_extension = end($matches);
             $this->filename = $file->name;
-            $path = $this->ParsedPath;
+            $path = $this->parsedPath;
         
             preg_match('|^(.*[\\\/])|', $path, $match);
             $folder = end($match);      
@@ -213,6 +213,18 @@ class AttachmentBehavior extends CActiveRecordBehavior {
     {
         $needle = array(':folder', ':model', ':id', ':ext', ':filename', ':custom');
         $replacement = array($this->folder, get_class($this->Owner), $this->Owner->primaryKey,$this->file_extension, $this->filename, $custom);
+        if(preg_match_all('/:\\{([^\\}]+)\\}/', $this->path, $matches, PREG_SET_ORDER)) {
+            foreach($matches as $match) {
+                $valuePath = explode('.', $match[1]);
+                $value = $this->owner;
+                foreach($valuePath as $attributeName) {
+                    if(is_object($value))
+                        $value = $value->{$attributeName};
+                }
+                $needle[] = $match[0];
+                $replacement[] = $value;
+            }
+        }
         return str_replace($needle, $replacement, $this->path);
     }    
 }
@@ -327,9 +339,8 @@ class ImagickProcessor
     
     public function setImageColorSpace($color_space = Imagick::COLORSPACE_GRAY)
     {
-    $im = new Imagick($this->image);
-    $im->setImageColorSpace($color_space);
-    $im->writeImage($this->output_path);
-    
+        $im = new Imagick($this->image);
+        $im->setImageColorSpace($color_space);
+        $im->writeImage($this->output_path);
     }
 }

--- a/AttachmentBehavior/AttachmentBehavior.php
+++ b/AttachmentBehavior/AttachmentBehavior.php
@@ -90,14 +90,14 @@ class AttachmentBehavior extends CActiveRecordBehavior {
     {
         if($style == ''){
             if($this->hasAttachment())
-                return $this->Owner->filename;
+                return $this->Owner->{$this->attribute};
             elseif($this->fallback_image != '')
                 return $this->fallback_image;
             else
                 return '';
         }else{
             if(isset($this->styles[$style])){
-                $im = preg_replace('/\.(.*)$/','-'.$style.'\\0',$this->Owner->filename);                
+                $im = preg_replace('/\.(.*)$/','-'.$style.'\\0',$this->Owner->{$this->attribute});                
                 if(file_exists($im))
                     return  $im;
                 elseif(isset($this->fallback_image))
@@ -112,7 +112,7 @@ class AttachmentBehavior extends CActiveRecordBehavior {
      */
     public function hasAttachment()
     {
-        return file_exists($this->Owner->filename);
+        return file_exists($this->Owner->{$this->attribute});
     }
     
     /**
@@ -342,5 +342,6 @@ class ImagickProcessor
         $im = new Imagick($this->image);
         $im->setImageColorSpace($color_space);
         $im->writeImage($this->output_path);
+    
     }
 }

--- a/README.md
+++ b/README.md
@@ -77,8 +77,24 @@ Create the upload folder and upload a file.
 To retrieve the image:
 ```php
 echo '<img src="'.$model->getAttachment('thumb').'" />'; //thumbnail
-echo '<img src="'.$model->Attachment.'" />'; //base image
+echo '<img src="'.$model->attachment.'" />'; //base image
 ```
+
+Advanced options
+----------------
+If you want you can use attribute values of the object that you extended in the path template. You can do this by referencing these attributes like this: 
+```php
+public function behaviors()
+{
+	return array(
+		'image' => array(
+			//...
+			'path' => ":folder/:{attributeName}/:id.:ext",
+			//...
+```
+Note that the curly braces are mandatory in this case.
+
+You can even use the attributes of a relation or a subrelation by using the `.` as a separator like so `:{relationName.attributeName}` or like so `:{relationName.subRelationName.attributeName}`. Note that this only works with HAS_ONE, BELONGS_TO or any other custom getter relation (that returns a single object instance and contains the given attribute name, duhh!! ;).
 
 Gotchas
 -------


### PR DESCRIPTION
Added the ability to make the path template use attributes of the owner object while saving the attachment like so `':folder/:{someAttributeOfTheOwner}/:id/:filename.:ext'`. You can even use attibutes of relations like so `:{user.username}`. Should also work with multiple relations through other relations like so `:{user.userSettings.imageSavePath}`. User has to a relation of the owner object. All the relations obviously need to be has_one or belongs_to for this to work. 
